### PR TITLE
Set default theme to be system and show dark/light mode toggle

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,8 +8,8 @@
     "dark": "#7C3EFF"
   },
   "appearance": {
-    "default": "light",
-    "strict": true
+    "default": "system",
+    "strict": false
   },
   "favicon": "/favicon.png",
   "navigation": {


### PR DESCRIPTION
There should be a choice for the user to choose the dark/light mode. Honestly, the default light theme burned my eyes (kind of) like Discord lol

So I set the default theme to be `system` and enabled the toggle button

In my opinion, this is a much better option for better user experience. Feel free to decide if you want only the light theme or this