### PR TITLE
docs(setup): update Tanstack Start integration example

### DIFF
--- a/setup.mdx
+++ b/setup.mdx
@@ -276,30 +276,30 @@ export default [
 ```
 
 ```typescript Tanstack Start
-// routes/api/autumn.$.ts
+// routes/api/autumn/$.ts
 
-import { createAPIFileRoute } from "@tanstack/react-start/api";
-import { auth } from "~/lib/auth";
-import { autumnHandler } from "autumn-js/tanstack";
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { autumnHandler } from 'autumn-js/tanstack';
+import { auth } from '@/lib/auth';
 
-const handler = autumnHandler({
-  identify: async ({ request }) => {
-    // get the user from your auth provider (example: better-auth)
-    const session = await auth.api.getSession({
-      headers: request.headers,
-    });
+export const ServerRoute = createServerFileRoute('/api/autumn/$').methods(
+  autumnHandler({
+    identify: async ({ request }) => {
+      // Get the user from your auth provider (example: better-auth)
+      const session = await auth.api.getSession({
+        headers: request.headers
+      });
 
-    return {
-      customerId: session?.user.id,
-      customerData: {
-        name: session?.user.name,
-        email: session?.user.email,
-      },
-    };
-  },
-});
-
-export const APIRoute = createAPIFileRoute("/api/autumn/$")(handler);
+      return {
+        customerId: session?.user.id,
+        customerData: {
+          name: session?.user.name,
+          email: session?.user.email
+        }
+      };
+    }
+  })
+);
 ```
 
 ```typescript Hono


### PR DESCRIPTION
## Description

Adds an updated integration example for TanStack Start to the Autumn documentation

## Why This Change Is Needed

TanStack Start requires using `createServerFileRoute` for API endpoints. This example shows developers how to properly integrate Autumn with TanStack Start's server route pattern.

## Reference

📚 [Documentation](https://tanstack.com/start/latest/docs/framework/react/server-routes)