### PR TITLE
docs: fix typo on credits page

### DIFF
--- a/features/credits.mdx
+++ b/features/credits.mdx
@@ -5,7 +5,7 @@ description: Learn how to create a credit system in Autumn
 
 {/* Creating credits, how it works with entitlements, that you should use the features not credits. monetary credits. */}
 
-Credit systems allow you to track and limit the usage of multiple different features from a shared balance. This can simplift billing when you have many different usage-based features, and they all cost different amounts.
+Credit systems allow you to track and limit the usage of multiple different features from a shared balance. This can simplify billing when you have many different usage-based features, and they all cost different amounts.
 
 ## Creating a credit system
 


### PR DESCRIPTION
Just fixed a quick typo:
<img width="215" height="131" alt="image" src="https://github.com/user-attachments/assets/1c802cc2-e69f-4f9c-981d-e973f1c86791" />


